### PR TITLE
fix: correct parsing logic for certificate VC schema issued by TA

### DIFF
--- a/source/did-ta-server/src/main/java/org/omnione/did/tas/v1/agent/service/VcServiceImpl.java
+++ b/source/did-ta-server/src/main/java/org/omnione/did/tas/v1/agent/service/VcServiceImpl.java
@@ -902,7 +902,7 @@ public class VcServiceImpl implements VcService {
 
                 String vcSchemaJson = CertificateVcSchemaProvider.getSchema(existedTas.getServerUrl());
 
-                return parseVcSchemaToMap(requestCertificateVc());
+                return parseVcSchemaToMap(vcSchemaJson);
             }
 
             ListVcSchema existingListVcSchema = listVcSchemaQueryService.findBySchemaId(id);


### PR DESCRIPTION
## Description  
Fixed a bug that occurred during app integration after the initial admin development phase was completed.

## Related Issue (Optional)  
- Issue #

## Changes  
- Fixed a bug where the certificate vc was mistakenly sent during VC schema fetch requests  

## Screenshots (Optional)  
<!-- Add screenshots or GIFs if necessary to illustrate the changes -->

## Additional Comments (Optional)  
